### PR TITLE
Apollo tickets query

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -62,9 +62,9 @@ type Query {
   ): Node
   siteStatistics: SiteStatistics!
   ticketsConnection(status: TicketStatus, after: String, first: Int, before: String, last: Int): TicketConnection!
-  tickets(status: TicketStatus, limit: Int!, offset: Int!): [Ticket]!
+  tickets(status: TicketStatus, limit: Int!, offset: Int!): [Ticket!]!
   todosConnection(after: String, first: Int, before: String, last: Int): TodoItemConnection!
-  todos(limit: Int!, offset: Int!): [TodoItem]!
+  todos(limit: Int!, offset: Int!): [TodoItem!]!
 }
 
 type SiteStatistics implements Node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -61,7 +61,8 @@ type Query {
     id: ID!
   ): Node
   siteStatistics: SiteStatistics!
-  tickets(status: TicketStatus, after: String, first: Int, before: String, last: Int): TicketConnection!
+  ticketsConnection(status: TicketStatus, after: String, first: Int, before: String, last: Int): TicketConnection!
+  tickets(status: TicketStatus, limit: Int!, offset: Int!): [Ticket]!
   todosConnection(after: String, first: Int, before: String, last: Int): TodoItemConnection!
   todos(limit: Int!, offset: Int!): [TodoItem]!
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,7 +16,8 @@ import {
   ticketConnection,
   todoConnection,
   nodeField,
-  todoItemType
+  todoItemType,
+  ticketType
 } from "./graphqlTypes";
 
 import { mutationType } from "./mutations";
@@ -30,7 +31,7 @@ let queryType = new GraphQLObjectType({
       type: new GraphQLNonNull(siteStatisticsType),
       resolve: () => siteStatistics
     },
-    tickets: {
+    ticketsConnection: {
       type: new GraphQLNonNull(ticketConnection.connectionType),
       args: { status: { type: ticketStatusEnum }, ...connectionArgs },
       resolve(root, args, obj) {
@@ -39,6 +40,28 @@ let queryType = new GraphQLObjectType({
             args.status ? ticket.status === args.status : true
           ),
           args
+        );
+      }
+    },
+    tickets: {
+      type: new GraphQLNonNull(new GraphQLList(ticketType)),
+      args: {
+        status: { type: ticketStatusEnum },
+        limit: {
+          type: new GraphQLNonNull(GraphQLInt)
+        },
+        offset: {
+          type: new GraphQLNonNull(GraphQLInt)
+        }
+      },
+      resolve(root, args, obj) {
+        const ticketsByStatus = tickets.filter(ticket =>
+          args.status ? ticket.status === args.status : true
+        );
+
+        return ticketsByStatus.slice(
+          parseInt(args.offset, 10),
+          parseInt(args.limit, 10)
         );
       }
     },

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -23,6 +23,9 @@ import {
 import { mutationType } from "./mutations";
 import { subscriptionType } from "./subscriptions";
 
+let paginate = <T>(offset: number, limit: number, array: T[]) => 
+  array.slice(offset, offset + limit);
+
 let queryType = new GraphQLObjectType({
   name: "Query",
   fields: () => ({
@@ -59,10 +62,10 @@ let queryType = new GraphQLObjectType({
           args.status ? ticket.status === args.status : true
         );
 
-        return ticketsByStatus.slice(
-          parseInt(args.offset, 10),
-          parseInt(args.limit, 10)
-        );
+        let offset = parseInt(args.offset, 10);
+        let limit = parseInt(args.limit, 10);
+        
+        return paginate(offset, limit, ticketsByStatus);
       }
     },
     todosConnection: {
@@ -83,10 +86,10 @@ let queryType = new GraphQLObjectType({
         }
       },
       resolve(root, args, obj) {
-        return todoItems.slice(
-          parseInt(args.offset, 10),
-          parseInt(args.limit, 10)
-        );
+        let offset = parseInt(args.offset, 10);
+        let limit = parseInt(args.limit, 10);
+
+        return paginate(offset, limit, todoItems);
       }
     }
   })


### PR DESCRIPTION
What this PR does:
- changes `tickets` to `ticketsConnection` (similar to `todos` and `todosConnection`) and adds a new query `tickets` to be used with `apollo` (similar to `todos`),
- fixes pagination with `slice` (second parameter to `slice` should be the end index of the slice operation),
- makes return type for `todos` non-nullable array of non-nullable `Todo` 😄 