### PR TITLE
Apollo paging and mutation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -63,9 +63,9 @@ type Query {
   userById(id: ID!): User
   siteStatistics: SiteStatistics!
   ticketsConnection(status: TicketStatus, after: String, first: Int, before: String, last: Int): TicketConnection!
-  tickets(status: TicketStatus, limit: Int!, offset: Int!): [Ticket]!
+  tickets(status: TicketStatus, limit: Int!, offset: Int!): TicketsPaginated!
   todosConnection(after: String, first: Int, before: String, last: Int): TodoItemConnection!
-  todos(limit: Int!, offset: Int!): [TodoItem]!
+  todos(limit: Int!, offset: Int!): TodosPaginated!
 }
 
 type SiteStatistics implements Node {
@@ -109,6 +109,11 @@ type TicketEdge {
   cursor: String!
 }
 
+type TicketsPaginated {
+  total: Int!
+  results: [Ticket!]!
+}
+
 enum TicketStatus {
   Done
   Progress
@@ -140,6 +145,11 @@ type TodoItemEdge {
 
   """A cursor for use in pagination"""
   cursor: String!
+}
+
+type TodosPaginated {
+  total: Int!
+  results: [TodoItem!]!
 }
 
 input UpdateTodoItemInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,10 +27,17 @@ type DeleteTodoItemPayload {
   clientMutationId: String
 }
 
+type DeleteTodoSimple {
+  deletedTodoItemId: ID!
+}
+
 type Mutation {
   addTodoItem(input: AddTodoItemInput!): AddTodoItemPayload
   updateTodoItem(input: UpdateTodoItemInput!): UpdateTodoItemPayload
   deleteTodoItem(input: DeleteTodoItemInput!): DeleteTodoItemPayload
+  addTodoSimple(text: String!): TodoItem!
+  updateTodoSimple(id: ID!, text: String!, completed: Boolean): TodoItem
+  deleteTodoSimple(id: ID!): DeleteTodoSimple
 }
 
 """An object with an ID"""
@@ -66,6 +73,7 @@ type Query {
   tickets(status: TicketStatus, limit: Int!, offset: Int!): TicketsPaginated!
   todosConnection(after: String, first: Int, before: String, last: Int): TodoItemConnection!
   todos(limit: Int!, offset: Int!): TodosPaginated!
+  allTodos: [TodoItem!]!
 }
 
 type SiteStatistics implements Node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -111,6 +111,7 @@ type TicketEdge {
 
 type TicketsPaginated {
   total: Int!
+  hasNextPage: Boolean!
   results: [Ticket!]!
 }
 
@@ -149,6 +150,7 @@ type TodoItemEdge {
 
 type TodosPaginated {
   total: Int!
+  hasNextPage: Boolean!
   results: [TodoItem!]!
 }
 

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -56,6 +56,19 @@ export let { nodeInterface, nodeField } = nodeDefinitions(
   }
 );
 
+const paginationDefinitions = (objectType: GraphQLObjectType, name: string) =>
+  new GraphQLObjectType({
+    name,
+    fields: () => ({
+      total: { type: new GraphQLNonNull(GraphQLInt) },
+      results: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(objectType))
+        )
+      }
+    })
+  });
+
 export let userType: GraphQLObjectType = new GraphQLObjectType({
   name: "User",
   fields: () => ({
@@ -187,6 +200,11 @@ export let ticketType: GraphQLObjectType = new GraphQLObjectType({
 
 export let ticketConnection = connectionDefinitions({ nodeType: ticketType });
 
+export let ticketsPaginatedType: GraphQLObjectType = paginationDefinitions(
+  ticketType,
+  "TicketsPaginated"
+);
+
 export let todoItemType: GraphQLObjectType = new GraphQLObjectType({
   name: "TodoItem",
   fields: () => ({
@@ -202,3 +220,8 @@ export let todoItemType: GraphQLObjectType = new GraphQLObjectType({
 });
 
 export let todoConnection = connectionDefinitions({ nodeType: todoItemType });
+
+export let todosPaginatedType: GraphQLObjectType = paginationDefinitions(
+  todoItemType,
+  "TodosPaginated"
+);

--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -61,6 +61,7 @@ const paginationDefinitions = (objectType: GraphQLObjectType, name: string) =>
     name,
     fields: () => ({
       total: { type: new GraphQLNonNull(GraphQLInt) },
+      hasNextPage: { type: new GraphQLNonNull(GraphQLBoolean) },
       results: {
         type: new GraphQLNonNull(
           new GraphQLList(new GraphQLNonNull(objectType))

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -11,61 +11,6 @@ import { todoItemType } from "./graphqlTypes";
 import { todoItems } from "./db";
 import { TodoItem, TodoUpdateInputType } from "./types";
 
-/** utils */
-let addTodo = (text: string) => {
-  let lastTodoItem = todoItems.slice().pop();
-  let nextIndex = lastTodoItem ? lastTodoItem.id + 1 : 1;
-
-  let newTodo: TodoItem = {
-    id: nextIndex,
-    type: "TodoItem",
-    text: text,
-    completed: false
-  };
-
-  todoItems.push(newTodo);
-  return {
-    addedTodoItem: newTodo
-  };
-};
-
-let updateTodo = (id: string, text: string, completed: boolean) => {
-  let { type, id: todoItemId } = fromGlobalId(id);
-  let targetTodoItem = todoItems.find(t => t.id === parseInt(todoItemId, 10));
-
-  if (!targetTodoItem || type !== "TodoItem") {
-    return {
-      updatedTodoItem: null
-    };
-  }
-
-  targetTodoItem.text = text;
-  targetTodoItem.completed = completed;
-
-  return {
-    updatedTodoItem: targetTodoItem
-  };
-};
-
-let deleteTodo = (id: string) => {
-  let { type, id: todoItemId } = fromGlobalId(id);
-  let targetTodoItemIndex = todoItems.findIndex(
-    t => t.id === parseInt(todoItemId, 10)
-  );
-
-  if (targetTodoItemIndex === -1 || type !== "TodoItem") {
-    return {
-      deleteTodoItemId: null
-    };
-  }
-
-  todoItems.splice(targetTodoItemIndex, 1);
-
-  return {
-    deletedTodoItemId: id
-  };
-};
-
 /** relay style mutations */
 let addTodoItemMutation = mutationWithClientMutationId({
   name: "AddTodoItem",
@@ -83,6 +28,23 @@ let addTodoItemMutation = mutationWithClientMutationId({
     return addTodo(text);
   }
 });
+
+let addTodo = (text: string) => {
+  let lastTodoItem = todoItems.slice().pop();
+  let nextIndex = lastTodoItem ? lastTodoItem.id + 1 : 1;
+
+  let newTodo: TodoItem = {
+    id: nextIndex,
+    type: "TodoItem",
+    text: text,
+    completed: false
+  };
+
+  todoItems.push(newTodo);
+  return {
+    addedTodoItem: newTodo
+  };
+};
 
 let updateTodoItemMutation = mutationWithClientMutationId({
   name: "UpdateTodoItem",
@@ -107,6 +69,24 @@ let updateTodoItemMutation = mutationWithClientMutationId({
   }
 });
 
+let updateTodo = (id: string, text: string, completed: boolean) => {
+  let { type, id: todoItemId } = fromGlobalId(id);
+  let targetTodoItem = todoItems.find(t => t.id === parseInt(todoItemId, 10));
+
+  if (!targetTodoItem || type !== "TodoItem") {
+    return {
+      updatedTodoItem: null
+    };
+  }
+
+  targetTodoItem.text = text;
+  targetTodoItem.completed = completed;
+
+  return {
+    updatedTodoItem: targetTodoItem
+  };
+};
+
 let deleteTodoItemMutation = mutationWithClientMutationId({
   name: "DeleteTodoItem",
   inputFields: () => ({
@@ -123,6 +103,25 @@ let deleteTodoItemMutation = mutationWithClientMutationId({
     return deleteTodo(id);
   }
 });
+
+let deleteTodo = (id: string) => {
+  let { type, id: todoItemId } = fromGlobalId(id);
+  let targetTodoItemIndex = todoItems.findIndex(
+    t => t.id === parseInt(todoItemId, 10)
+  );
+
+  if (targetTodoItemIndex === -1 || type !== "TodoItem") {
+    return {
+      deleteTodoItemId: null
+    };
+  }
+
+  todoItems.splice(targetTodoItemIndex, 1);
+
+  return {
+    deletedTodoItemId: id
+  };
+};
 
 /** apollo style */
 let addTodoSimple: GraphQLFieldConfig<any, any, any> = {

--- a/src/mutations.ts
+++ b/src/mutations.ts
@@ -4,12 +4,69 @@ import {
   GraphQLBoolean,
   GraphQLString,
   GraphQLNonNull,
-  GraphQLID
+  GraphQLID,
+  GraphQLFieldConfig
 } from "graphql";
 import { todoItemType } from "./graphqlTypes";
 import { todoItems } from "./db";
-import { TodoItem } from "./types";
+import { TodoItem, TodoUpdateInputType } from "./types";
 
+/** utils */
+let addTodo = (text: string) => {
+  let lastTodoItem = todoItems.slice().pop();
+  let nextIndex = lastTodoItem ? lastTodoItem.id + 1 : 1;
+
+  let newTodo: TodoItem = {
+    id: nextIndex,
+    type: "TodoItem",
+    text: text,
+    completed: false
+  };
+
+  todoItems.push(newTodo);
+  return {
+    addedTodoItem: newTodo
+  };
+};
+
+let updateTodo = (id: string, text: string, completed: boolean) => {
+  let { type, id: todoItemId } = fromGlobalId(id);
+  let targetTodoItem = todoItems.find(t => t.id === parseInt(todoItemId, 10));
+
+  if (!targetTodoItem || type !== "TodoItem") {
+    return {
+      updatedTodoItem: null
+    };
+  }
+
+  targetTodoItem.text = text;
+  targetTodoItem.completed = completed;
+
+  return {
+    updatedTodoItem: targetTodoItem
+  };
+};
+
+let deleteTodo = (id: string) => {
+  let { type, id: todoItemId } = fromGlobalId(id);
+  let targetTodoItemIndex = todoItems.findIndex(
+    t => t.id === parseInt(todoItemId, 10)
+  );
+
+  if (targetTodoItemIndex === -1 || type !== "TodoItem") {
+    return {
+      deleteTodoItemId: null
+    };
+  }
+
+  todoItems.splice(targetTodoItemIndex, 1);
+
+  return {
+    deletedTodoItemId: id
+  };
+};
+
+/** relay style mutations */
 let addTodoItemMutation = mutationWithClientMutationId({
   name: "AddTodoItem",
   inputFields: () => ({
@@ -23,21 +80,7 @@ let addTodoItemMutation = mutationWithClientMutationId({
     }
   }),
   mutateAndGetPayload: ({ text }) => {
-    let lastTodoItem = todoItems.slice().pop();
-    let nextIndex = lastTodoItem ? lastTodoItem.id + 1 : 1;
-
-    let newTodo: TodoItem = {
-      id: nextIndex,
-      type: "TodoItem",
-      text: text,
-      completed: false
-    };
-
-    todoItems.push(newTodo);
-
-    return {
-      addedTodoItem: newTodo
-    };
+    return addTodo(text);
   }
 });
 
@@ -60,21 +103,7 @@ let updateTodoItemMutation = mutationWithClientMutationId({
     }
   }),
   mutateAndGetPayload: ({ text, completed, id }) => {
-    let { type, id: todoItemId } = fromGlobalId(id);
-    let targetTodoItem = todoItems.find(t => t.id === parseInt(todoItemId, 10));
-
-    if (!targetTodoItem || type !== "TodoItem") {
-      return {
-        updatedTodoItem: null
-      };
-    }
-
-    targetTodoItem.text = text;
-    targetTodoItem.completed = completed;
-
-    return {
-      updatedTodoItem: targetTodoItem
-    };
+    return updateTodo(id, text, completed);
   }
 });
 
@@ -91,30 +120,59 @@ let deleteTodoItemMutation = mutationWithClientMutationId({
     }
   }),
   mutateAndGetPayload: ({ id }) => {
-    let { type, id: todoItemId } = fromGlobalId(id);
-    let targetTodoItemIndex = todoItems.findIndex(
-      t => t.id === parseInt(todoItemId, 10)
-    );
-
-    if (targetTodoItemIndex === -1 || type !== "TodoItem") {
-      return {
-        deleteTodoItemId: null
-      };
-    }
-
-    todoItems.splice(targetTodoItemIndex, 1);
-
-    return {
-      deletedTodoItemId: id
-    };
+    return deleteTodo(id);
   }
 });
+
+/** apollo style */
+let addTodoSimple: GraphQLFieldConfig<any, any, any> = {
+  type: new GraphQLNonNull(todoItemType),
+  args: {
+    text: { type: new GraphQLNonNull(GraphQLString) }
+  },
+  resolve(_, { text }) {
+    return addTodo(text).addedTodoItem;
+  }
+};
+
+let updateTodoSimple: GraphQLFieldConfig<any, any, any> = {
+  type: todoItemType,
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    text: { type: new GraphQLNonNull(GraphQLString) },
+    completed: { type: GraphQLBoolean }
+  },
+  resolve(_, { id, text, completed }: TodoUpdateInputType) {
+    return updateTodo(id, text, completed).updatedTodoItem;
+  }
+};
+
+let deleteTodoSimple: GraphQLFieldConfig<any, any, any> = {
+  type: new GraphQLObjectType({
+    name: "DeleteTodoSimple",
+    fields: () => ({
+      deletedTodoItemId: {
+        type: new GraphQLNonNull(GraphQLID)
+      }
+    })
+  }),
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLID) }
+  },
+  resolve(_, { id }) {
+    return deleteTodo(id);
+  }
+};
 
 export let mutationType = new GraphQLObjectType({
   name: "Mutation",
   fields: () => ({
     addTodoItem: addTodoItemMutation,
     updateTodoItem: updateTodoItemMutation,
-    deleteTodoItem: deleteTodoItemMutation
+    deleteTodoItem: deleteTodoItemMutation,
+    // apollo style
+    addTodoSimple,
+    updateTodoSimple,
+    deleteTodoSimple
   })
 });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -81,12 +81,7 @@ let queryType = new GraphQLObjectType({
         const offset = parseInt(args.offset, 10);
         const limit = parseInt(args.limit, 10);
 
-        const results = paginate(offset, limit, ticketsByStatus);
-
-        return {
-          results,
-          total: ticketsByStatus.length
-        };
+        return paginate(offset, limit, ticketsByStatus);
       }
     },
     todosConnection: {
@@ -110,12 +105,7 @@ let queryType = new GraphQLObjectType({
         const offset = parseInt(args.offset, 10);
         const limit = parseInt(args.limit, 10);
 
-        const results = paginate(offset, limit, todoItems);
-
-        return {
-          results,
-          total: todoItems.length
-        };
+        return paginate(offset, limit, todoItems);
       }
     }
   })

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3,7 +3,8 @@ import {
   GraphQLObjectType,
   GraphQLNonNull,
   GraphQLInt,
-  GraphQLID
+  GraphQLID,
+  GraphQLList
 } from "graphql";
 
 import {
@@ -23,7 +24,8 @@ import {
   nodeField,
   userType,
   ticketsPaginatedType,
-  todosPaginatedType
+  todosPaginatedType,
+  todoItemType
 } from "./graphqlTypes";
 
 import { mutationType } from "./mutations";
@@ -106,6 +108,14 @@ let queryType = new GraphQLObjectType({
         const limit = parseInt(args.limit, 10);
 
         return paginate(offset, limit, todoItems);
+      }
+    },
+    allTodos: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(todoItemType))
+      ),
+      resolve(): TodoItem[] {
+        return todoItems;
       }
     }
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,3 +48,9 @@ export type PaginatedList<T> = {
   hasNextPage: boolean;
   results: T[];
 };
+
+export type TodoUpdateInputType = {
+  id: string;
+  text: string;
+  completed: boolean;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,5 +45,6 @@ export type TodoItem = {
 
 export type PaginatedList<T> = {
   total: number;
+  hasNextPage: boolean;
   results: T[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,8 @@ export type TodoItem = {
   text: string;
   completed: boolean;
 };
+
+export type PaginatedList<T> = {
+  total: number;
+  results: T[];
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,11 @@
-export let paginate = <T>(offset: number, limit: number, array: T[]) =>
-  array.slice(offset, offset + limit);
+import { PaginatedList } from "./types";
+
+export let paginate = <T>(
+  offset: number,
+  limit: number,
+  array: T[]
+): PaginatedList<T> => ({
+  results: array.slice(offset, offset + limit),
+  hasNextPage: offset + limit < array.length,
+  total: array.length
+});


### PR DESCRIPTION
This PR:
- adds pagination meta data for numbered pages (limit/offset) for tickets and todos for apollo case,
- implements todo mutations (update/delete) without relay specific details to be used with apollo client,
- adds a query to fetch all todos to make it easier to demo simple queries without pagination.