### PR TITLE
Fix graphql-js@16.0.0 compatibility for `node`

### DIFF
--- a/src/graphqlTypes.ts
+++ b/src/graphqlTypes.ts
@@ -40,20 +40,7 @@ export let { nodeInterface, nodeField } = nodeDefinitions(
     return null;
   },
   // @ts-ignore
-  (obj: { type: string }) => {
-    switch (obj.type) {
-      case 'User':
-        return userType;
-      case 'WorkingGroup':
-        return workingGroupType;
-      case 'SiteStatistics':
-        return siteStatisticsType;
-      case 'Ticket':
-        return ticketType;
-      case 'TodoItem':
-        return todoItemType;
-    }
-  }
+  (obj: { type: string }) => obj.type
 );
 
 const paginationDefinitions = (objectType: GraphQLObjectType, name: string) =>


### PR DESCRIPTION
This fixes the following error that was being returned instead.

> Support for returning GraphQLObjectType from resolveType was removed in graphql-js@16.0.0 please return type name instead.